### PR TITLE
2 Sets of Keys

### DIFF
--- a/server/config/keys.js
+++ b/server/config/keys.js
@@ -1,0 +1,6 @@
+// keys.js - figure out what set of credentials to return
+if (process.env.NODE_ENV === 'production') { //we are in production - return the production set of keys
+    module.exports = require('./prod');    //when our server is deployed to heroku an environment variable exists called NODE_ENV which tells us if we are running in production or not
+} else {                                   //we are in development and on our local machine - return the dev keys
+    module.exports = require('./dev')
+}

--- a/server/config/prod.js
+++ b/server/config/prod.js
@@ -1,0 +1,7 @@
+//prod.js - production keys here
+module.exports = {                                                                              
+    googleClientID: process.env.GOOGLE_CLIENT_ID,             //'process.env'means find out environment variables
+    googleClientSecret: process.env.GOOGLE_CLIENT_SECRET,     //the '_' underscores are just a convention to follow                                      
+    mongoURI: process.env.MONGO_URI,
+    cookieKey: process.env.COOKIE_KEY
+}

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,7 @@ mongoose.connect(keys.mongoURI); // we pass the address of the mongoose instance
 
 const app = express();
 
+//////////////////////////////////////////////////MIDDLEWARE used for every incoming request before entering the route handlers?/////////
 app.use(
     cookieSession({                       //cookieSession helps express handle cookies, cookie takes two arguments maxAge and keys
         maxAge: 30 * 24 * 60 * 60 * 1000,
@@ -19,6 +20,7 @@ app.use(
 
 app.use(passport.initialize());            //these two functions tell passport to use cookies to handle authentication
 app.use(passport.session()); 
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 require('./routes/authRoutes')(app);         //passing the app object created by const app = express(), to the function authroutes that we created and imported
 


### PR DESCRIPTION
Creates two sets of keys:
One for production names prod.js, which uses heroku environment variables
Another for development dev.js, which is added to .gitignore and will be available when app is run locally.